### PR TITLE
feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY . .
 RUN chmod -R 775 /performance-dashboards
 
 # Install dependencies
-RUN pip3 install --upgrade pip && \
-    pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir -r requirements.txt
 
 # Start the command
 CMD ["python3", "dittybopper/syncer/entrypoint.py"]


### PR DESCRIPTION
Using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6